### PR TITLE
feat: add slash command action to move project cards

### DIFF
--- a/.github/workflows/slash-command-action.yml
+++ b/.github/workflows/slash-command-action.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "The command is '${{ env.COMMAND }}'"
           echo "github.event.issue.node_id is ${{ github.event.issue.node_id }}"
-      - name: Get project card ID
+      - name: Get project card
         if: env.VALID_COMMAND == 'true'
         uses: actions/github-script@v7
         env:
@@ -68,6 +68,7 @@ jobs:
                     edges {
                       node {
                         id
+                        url
                         items(first: 100) {
                           edges {
                             node {
@@ -93,16 +94,19 @@ jobs:
             const result = await github.graphql(query, variables);
             console.log(`Result: ${JSON.stringify(result)}`);
             const cardId = result.node.projectsV2.edges[0].node.items.edges.find(edge => edge.node.content.id === process.env.ISSUE_NODE_ID).node.id;
+            const projectUrl = result.node.projectsV2.edges[0].node.url;
             console.log(`Card ID: ${cardId}`);
+            console.log(`Project URL: ${projectUrl}`);
             core.setOutput('cardId', cardId);
+            core.setOutput('projectUrl', projectUrl);
           github-token: ${{ secrets.MOVE_CARDS_TOKEN }}
-        id: get_card_id
+        id: get_card
       - name: Update project
         if: env.VALID_COMMAND == 'true'
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/sidemt/projects/3
+          project-url: ${{ steps.get_card.outputs.projectUrl }}
           github-token: ${{ secrets.MOVE_CARDS_TOKEN }}
-          item-id: ${{ steps.get_card_id.outputs.cardId }}
+          item-id: ${{ steps.get_card.outputs.cardId }}
           field-keys: Status
           field-values: ${{ env.TARGET_STATUS }}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Preparation:
- Generate personal access tokens (classic) with full access to `project`, set it in the repository's Settings > Secrets and variables > Actions > Repository secrets as `MOVE_CARDS_TOKEN`
- The project board must have a field named `Status`, and the values for it `in Translation` and `in Review`, as shown in the [template project](https://github.com/orgs/freeCodeCamp/projects/46)

How to run: 
- Adding a new comment starting with `/` command will update the status. Available commands are:
    - `/translate` (moves the card to `in Translation`)
    - `/review` (moves the card to `in Review`)
- If a user comments an invalid command, user will get a comment telling that the command was invalid.
- If a user adds a normal comment (not starting with `/`), the action will be skipped.

Things not implemented yet:
- Ability to notify the language lead who is in charge
- Ability to validate where the card is moved from (e.g. we might want to prevent users moving the cards from Review to Translate)
- Ability to assign the issue to the collaborator who made the `/translation` comment