### PR TITLE
Fixed the bug where only one action could be triggered per article.

### DIFF
--- a/.github/workflows/ArticlesAutoTranslate.yml
+++ b/.github/workflows/ArticlesAutoTranslate.yml
@@ -26,28 +26,31 @@ jobs:
 
       - uses: actions/checkout@v3
       - name: Crawl pages and generate Markdown files
-        uses: freeCodeCamp-China/article-webpage-to-markdown-action@v1
+        id: fetch-webpage-to-markdown
+        continue-on-error: true
+        uses: budblack/article-webpage-to-markdown-action@dev
         with:
           newsLink: '${{ github.event.issue.Body }}'
+          includeSelector: 'span.author-card-name,section.post-full-content'
           ignoreSelector: '.ad-wrapper'
-          markDownFilePath: './articles/_raw/'
-          githubToken: ${{ github.token }}
+          skipSameArticleCheck: true
+          skipIssueComment: true
+          markDownFilePath: './articles/_tmp/'
+          githubToken: '${{ github.token }}'
 
-      # Use this repo-self as an action
-      - uses: actions/checkout@v3
       - name: Articles auto translate
-        uses: budblack/news-translation-allinone@main
+        uses: budblack/articles-auto-translate-action@main
         with:
           with_issue_title: '${{ github.event.issue.title }}'
           with_issue_body: '${{ github.event.issue.Body }}'
           with_github_token: '${{ github.token }}'
-          with_task_fetch_and_save_force: false
+          with_orginal_markdown_file_path: ${{ steps.fetch-webpage-to-markdown.outputs.markdown_file_path }}
           with_task_fetch_to_save_path: './articles/_raw/'
           with_task_fetch_to_include_selector: '.author-card-name,.post-content'
           with_task_fetch_to_ignore_selector: '.ad-wrapper'
           with_task_translate_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           with_task_translate_to_save_path: './articles/{lang}/'
-
+          
       # Commit the local changes
       - name: Git Auto Commit
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/articles/_raw/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
+++ b/articles/_raw/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
@@ -1,7 +1,7 @@
 ---
 title: How to get a FAANG Dev Job in your 40s with Coding Interview University
   creator John Washam [#134]
-date: 2024-07-31T10:36:48.581Z
+date: 2024-07-31T10:37:42.527Z
 author: Quincy Larson
 authorURL: https://www.freecodecamp.org/news/author/quincy/
 originalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/

--- a/articles/_raw/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
+++ b/articles/_raw/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
@@ -1,12 +1,12 @@
 ---
 title: How to get a FAANG Dev Job in your 40s with Coding Interview University
   creator John Washam [#134]
-date: 2024-07-28T08:28:28.746Z
+date: 2024-07-31T10:36:48.581Z
 author: Quincy Larson
 authorURL: https://www.freecodecamp.org/news/author/quincy/
-OriginalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/
-Proofreader: ""
-
+originalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/
+translator: ""
+reviewer: ""
 ---
 
 On this week's episode of the podcast, I interview John Washam, a software engineer at Amazon. John's also creator of one of the most popular open source projects of all time, Coding Interview University.
@@ -47,8 +47,22 @@ Links we talk about during our conversation:
 -   Follow John on LinkedIn: [https://www.linkedin.com/in/johnawasham/][5]
     
 
+---
+
+![Quincy Larson](https://cdn.hashnode.com/res/hashnode/image/upload/v1640878938509/PLqvxeH9g.jpeg)
+
+Read [more posts][6].
+
+---
+
+If you read this far, thank the author to show them you care. Say Thanks
+
+Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. [Get started][7]
+
 [1]: https://www.freecodecamp.org/donate
 [2]: https://github.com/jwasham/coding-interview-university
 [3]: https://startupnextdoor.com/
 [4]: https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X
 [5]: https://www.linkedin.com/in/johnawasham/
+[6]: /news/author/quincy/
+[7]: https://www.freecodecamp.org/learn/

--- a/articles/ja-jp/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
+++ b/articles/ja-jp/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
@@ -1,0 +1,68 @@
+---
+title: 40代でFAANGの開発者職に就くには - コーディングインタビュー大学での奮闘
+  クリエイター ジョン・ワシャム [#134]
+date: 2024-07-31T10:37:42.527Z
+author: クインシー・ラーソン
+authorURL: https://www.freecodecamp.org/news/author/quincy/
+originalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/
+translator: ""
+reviewer: ""
+---
+
+今週のポッドキャストでは、アマゾンでソフトウェアエンジニアをしているジョン・ワシャムにインタビューしました。ジョンは、史上最も人気のあるオープンソースプロジェクトの一つ「コーディングインタビュー大学」の創設者でもあります。
+
+<!-- more -->
+
+これはジョンにとって初めてのポッドキャストインタビューであり、彼の物語を初めて語る機会でもありました。彼にインタビューすることは絶対的な名誉でした。
+
+私たちは以下のことについて話しました：
+
+- ジョンが90年代にピザ配送をして初めてのコンピュータを買うためにお金を貯めた方法。「貧乏な子供でいるのにうんざりしていた。」
+    
+- ジョンの最初のキャリアであるアメリカ軍での勤務経験。彼は韓国で翻訳者として働いていました
+    
+- ジョンが8か月間でコンピュータサイエンスを猛勉強し、大手テック企業に就職できるだけの理論とコーディングスキルを独学で身に付け、その後GitHubに「コーディングインタビュー大学」を公開した方法
+    
+- 大手テック企業のシニア開発者として働くことの実際の姿と、その過程で期待すること
+    
+イントロで演奏しているベースの曲は何か分かりますか？これは1986年のロックソングの一部です。
+
+また、毎月私たちのチャリティを支援してくれる9,779人の親切な方々に感謝したいと思います。これらの方々のおかげでこのポッドキャストは実現しています。あなたも賛同して私たちのミッションをサポートできます： [https://www.freecodecamp.org/donate][1]
+
+このインタビューはYouTubeで見ることができます：
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/B-QBZrkD06U" style="aspect-ratio: 16 / 9; width: 100%; height: auto;" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy"></iframe>
+
+またはApple Podcasts、Spotify、またはあなたのお気に入りのポッドキャストアプリで聴くことができます。必ずfreeCodeCampポッドキャストをフォローして、毎週金曜日に新しいエピソードを手に入れましょう。
+
+会話中に話題にしたリンク：
+
+- コーディングインタビュー大学: [https://github.com/jwasham/coding-interview-university][2]
+    
+- The Starup Next Door, ジョンのブログ: [https://startupnextdoor.com/][3]
+    
+- ジョンが勧める書籍「The Talent Code」: [https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X][4]
+    
+- LinkedInでジョンをフォロー: [https://www.linkedin.com/in/johnawasham/][5]
+    
+
+---
+
+![クインシー・ラーソン](https://cdn.hashnode.com/res/hashnode/image/upload/v1640878938509/PLqvxeH9g.jpeg)
+
+[他の投稿を読む][6]
+
+---
+
+ここまで読んだなら、著者に感謝を示して彼らを応援しましょう。感謝の言葉を伝える
+
+無料でコーディングを学びましょう。freeCodeCampのオープンソースカリキュラムは、4万人以上の人々がデベロッパーとしての職を得るのを助けてきました。[始めましょう][7]
+
+[1]: https://www.freecodecamp.org/donate
+[2]: https://github.com/jwasham/coding-interview-university
+[3]: https://startupnextdoor.com/
+[4]: https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X
+[5]: https://www.linkedin.com/in/johnawasham/
+[6]: /news/author/quincy/
+[7]: https://www.freecodecamp.org/learn/
+

--- a/articles/zh-cn/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
+++ b/articles/zh-cn/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134.md
@@ -1,56 +1,70 @@
 ---
-title: 如何在 40 岁时通过编码面试大学获得 FAANG 开发工作 —— John Washam [#134]
-date: 2024-07-28T08:28:28.746Z
+title: 如何在40岁时通过编码面试大学找到FAANG开发工作
+  creator John Washam [#134]
+date: 2024-07-31T10:36:48.581Z
 author: Quincy Larson
 authorURL: https://www.freecodecamp.org/news/author/quincy/
-OriginalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/
-Proofreader: ""
-
+originalURL: https://www.freecodecamp.org/news/how-john-washam-crammed-for-8-months-got-a-job-at-amazon-then-taught-1000s-of-other-devs-134/
+translator: ""
+reviewer: ""
 ---
 
-在本周的播客节目中，我采访了亚马逊的软件工程师 John Washam。他也是有史以来最受欢迎的开源项目之一 —— 编码面试大学（Coding Interview University）的创建者。
+在本周的播客节目中，我采访了亚马逊的软件工程师John Washam。John也是有史以来最受欢迎的开源项目之一——编码面试大学（Coding Interview University）的创始人。
 
 <!-- more -->
 
-这是 John 第一次参加播客采访，也是他第一次讲述自己的故事。采访他真是无上的荣耀。
+这是John第一次接受播客采访，也是他第一次讲述自己的故事。采访他是我的莫大荣幸。
 
-我们聊到了：
+我们谈到了：
 
--   John 为了存钱买第一台电脑，在 90 年代送披萨的经历。“我厌倦了做一个没钱的孩子。”
+-   John在90年代送披萨攒钱买第一台电脑的经历。“我受够了做一个穷小子的生活。”
     
--   John 在美军的第一份职业生涯，他在韩国担任翻译
+-   John在美国军队的第一份职业生涯，他在韩国担任翻译
     
--   John 如何在 8 个月内突击学习计算机科学，自学了足够的理论和编码技能以获得大公司的工作，然后在 GitHub 上发布了编码面试大学
+-   John是如何在8个月内猛攻计算机科学，自学足够的理论和编码技能，进入大公司工作，然后在GitHub上发布了编码面试大学
     
--   在大公司作为高级开发人员工作是什么感觉，以及你可以期待这个旅程会是怎样的
+-   作为一个大科技公司的高级开发者的工作体验，以及你可以期待的职业历程
     
 
-你能猜到我在前奏中用低音吉他演奏的是什么歌吗？这是 1986 年的一首摇滚歌曲。
+你能猜到我在片头弹贝司时在演奏哪首歌吗？这是1986年的一首摇滚歌曲。
 
-此外，我要感谢每月支持我们慈善事业的 9,779 位善良的人，是他们让这个播客成为可能。你也可以加入他们，支持我们的使命：[https://www.freecodecamp.org/donate][1]
+另外，我想感谢每月支持我们慈善事业的9,779位好心人，使我们这个播客成为可能。你也可以加入他们，支持我们的使命：[https://www.freecodecamp.org/donate][1]
 
-你可以在 YouTube 上观看采访：
+你可以在YouTube上观看这次采访：
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/B-QBZrkD06U" style="aspect-ratio: 16 / 9; width: 100%; height: auto;" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/B-QBZrkD06U" style="aspect-ratio: 16 / 9; width: 100%; height: auto;" title="YouTube视频播放器" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy"></iframe>
 
-或者你可以在 Apple Podcasts、Spotify 或你喜欢的播客应用中收听。一定要在那里关注 freeCodeCamp 播客，这样你每周五都能收听到新的节目。
+或者你可以在Apple Podcasts、Spotify或你喜欢的播客应用中收听这个节目。一定要在这些平台上关注freeCodeCamp播客，这样你就能每周五收听到新节目。
 
-在我们的对话中提到的链接：
+我们在对话中提到的链接：
 
 -   编码面试大学: [https://github.com/jwasham/coding-interview-university][2]
     
--   John's 博客，The Starup Next Door: [https://startupnextdoor.com/][3]
+-   John's博客The Starup Next Door: [https://startupnextdoor.com/][3]
     
--   John 推荐的书籍《天才密码》: [https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X][4]
+-   John推荐的书《天才密码》: [https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X][4]
     
--   在 LinkedIn 上关注 John: [https://www.linkedin.com/in/johnawasham/][5]
+-   在LinkedIn上关注John: [https://www.linkedin.com/in/johnawasham/][5]
     
+
+---
+
+![Quincy Larson](https://cdn.hashnode.com/res/hashnode/image/upload/v1640878938509/PLqvxeH9g.jpeg)
+
+阅读[更多文章][6].
+
+---
+
+如果你读到了这里，感谢作者用以表示你的关心。说声谢谢
+
+免费学习编码。freeCodeCamp的开源课程已帮助超过40,000人找到开发者工作。[开始学习][7]
 
 [1]: https://www.freecodecamp.org/donate
 [2]: https://github.com/jwasham/coding-interview-university
 [3]: https://startupnextdoor.com/
 [4]: https://www.amazon.com/Talent-Code-Greatness-Born-Grown/dp/055380684X
 [5]: https://www.linkedin.com/in/johnawasham/
-
+[6]: /news/author/quincy/
+[7]: https://www.freecodecamp.org/learn/
 
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

fix: Fixed the bug where only one action could be triggered per article.

Currently, I can only use the article scraping action with my modified code to interface with the automatic translation action I wrote.

I tried to merge my modified scraping logic into the original repository, but it was not accepted because it did not align with the original repository's design principles.

However, I received permission from the original script author to use parts of the logic for extracting web articles and formatting them into markdown files in my forked version.

Now, I just need to transfer the prepared two action repositories to the organization (both action repositories can remain under the BSD license, and the new article storage repository can remain under the CC license).

<!-- Feel free to add any additional description of changes below this line -->
