### PR TITLE
fix: use new repos under fcc org

### DIFF
--- a/.github/workflows/ArticlesAutoTranslate.yml
+++ b/.github/workflows/ArticlesAutoTranslate.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Crawl pages and generate Markdown files
         id: fetch-webpage-to-markdown
         continue-on-error: true
-        uses: budblack/article-webpage-to-markdown-action@dev
+        uses: freeCodeCamp/article-webpage-to-markdown-action@dev
         with:
           newsLink: '${{ github.event.issue.Body }}'
           includeSelector: 'span.author-card-name,section.post-full-content'
@@ -39,7 +39,7 @@ jobs:
           githubToken: '${{ github.token }}'
 
       - name: Articles auto translate
-        uses: budblack/articles-auto-translate-action@main
+        uses: freeCodeCamp/articles-auto-translate-action@main
         with:
           with_issue_title: '${{ github.event.issue.title }}'
           with_issue_body: '${{ github.event.issue.Body }}'
@@ -50,7 +50,7 @@ jobs:
           with_task_fetch_to_ignore_selector: '.ad-wrapper'
           with_task_translate_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           with_task_translate_to_save_path: './articles/{lang}/'
-          
+
       # Commit the local changes
       - name: Git Auto Commit
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Updated the workflow file to use new repositories that have been transferred to freeCodeCamp organization.

I have tested this change in my personal fork.
