### PR TITLE
feat: update includeSelector in ArticlesAutoTranslate workflow

### DIFF
--- a/.github/workflows/ArticlesAutoTranslate.yml
+++ b/.github/workflows/ArticlesAutoTranslate.yml
@@ -28,7 +28,7 @@ jobs:
         uses: freeCodeCamp/article-webpage-to-markdown-action@dev
         with:
           newsLink: '${{ github.event.issue.Body }}'
-          includeSelector: 'span.author-card-name,section.post-full-content'
+          includeSelector: 'span.author-card-name,section.post-content'
           ignoreSelector: '.ad-wrapper'
           skipSameArticleCheck: true
           skipIssueComment: true

--- a/articles/_raw/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137.md
+++ b/articles/_raw/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137.md
@@ -1,7 +1,7 @@
 ---
 title: "Rahul Pandey quit his $800,000/year FAANG developer job to build a
   startup [Podcast #137]"
-date: 2024-08-16T13:23:48.142Z
+date: 2024-08-18T10:55:05.623Z
 author: Quincy Larson
 authorURL: https://www.freecodecamp.org/news/author/quincy/
 originalURL: https://www.freecodecamp.org/news/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137/
@@ -49,18 +49,6 @@ Links we talk about during our conversation:
 -   Rahul on LinkedIn: [https://www.linkedin.com/in/rpandey1234/][7]
     
 
----
-
-![Quincy Larson](https://cdn.hashnode.com/res/hashnode/image/upload/v1640878938509/PLqvxeH9g.jpeg)
-
-Read [more posts][8].
-
----
-
-If you read this far, thank the author to show them you care. Say Thanks
-
-Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. [Get started][9]
-
 [1]: https://www.freecodecamp.org/donate
 [2]: https://www.freecodecamp.org/news/learn-how-to-build-and-publish-an-android-app-from-scratch/
 [3]: https://www.youtube.com/watch?v=rceUVaiXQgU
@@ -68,5 +56,3 @@ Learn to code for free. freeCodeCamp's open source curriculum has helped more th
 [5]: https://anandsanwal.me/2018/06/19/dad-company-sale/
 [6]: https://www.youtube.com/watch?v=VpPPHDxR9aM
 [7]: https://www.linkedin.com/in/rpandey1234/
-[8]: /news/author/quincy/
-[9]: https://www.freecodecamp.org/learn/

--- a/articles/_raw/remove-underline-from-link-in-css.md
+++ b/articles/_raw/remove-underline-from-link-in-css.md
@@ -1,6 +1,6 @@
 ---
 title: How to Remove Underline from a Link in CSS – HTML Style Guide
-date: 2024-08-14T09:21:50.965Z
+date: 2024-08-18T10:50:38.140Z
 author: Kolade Chris
 authorURL: https://www.freecodecamp.org/news/author/koladechris/
 originalURL: https://www.freecodecamp.org/news/remove-underline-from-link-in-css/
@@ -76,17 +76,3 @@ I hope this article helps you learn how to remove the default underline from lin
 If you find the article helpful, don’t hesitate to share it with your friends and family.
 
 Thanks for reading.
-
----
-
-![Kolade Chris](https://cdn.hashnode.com/res/hashnode/image/upload/v1720467520534/YTa5HE3R0.jpg)
-
-I'm a software developer and tech writer focusing on frontend technologies
-
----
-
-If you read this far, thank the author to show them you care. Say Thanks
-
-Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. [Get started][1]
-
-[1]: https://www.freecodecamp.org/learn/

--- a/articles/ja/remove-underline-from-link-in-css.md
+++ b/articles/ja/remove-underline-from-link-in-css.md
@@ -1,6 +1,6 @@
 ---
-title: リンクの下線を CSS で消す方法 - HTML スタイルガイド
-date: 2024-08-14T09:21:50.965Z
+title: CSS でリンクの下線を消す方法 – HTML スタイルガイド
+date: 2024-08-18T10:50:38.140Z
 author: Kolade Chris
 authorURL: https://www.freecodecamp.org/news/author/koladechris/
 originalURL: https://www.freecodecamp.org/news/remove-underline-from-link-in-css/
@@ -8,86 +8,72 @@ translator: ""
 reviewer: ""
 ---
 
-ウェブ開発者なら、ページにリンクを追加した際のデフォルトの下線を消したいと思ったことがあるでしょう。
+ウェブ開発者であれば、ページにリンクを追加した際にデフォルトで表示される下線を消したいと思ったことがあるでしょう。
 
 <!-- more -->
 
-幸運なことに、ウェブページの他の要素と同様に、リンクを表示するアンカータグもスタイリングできます。
+幸いなことに、他のウェブページ要素と同様に、リンクを表示するための anchor タグもスタイルを設定できます。
 
-この記事では、CSS を使ってリンクの下線を消す方法を紹介します。さらに、リンクが持つ 4 つの状態と、それぞれの状態で下線を消す方法についても解説します。
+この記事では、CSS でリンクの下線を消す方法を紹介します。また、リンクが持つ 4 つの状態と、それぞれの状態で下線を削除する方法も説明します。
 
 ## CSS でリンクの下線を消す方法
 
-デフォルトでは、リンクタグは以下のようにブラウザに表示されます: ![ss1-4](https://www.freecodecamp.org/news/content/images/2022/06/ss1-4.png)
+デフォルトでは、リンクタグはブラウザで次のように表示されます: ![ss1-4](https://www.freecodecamp.org/news/content/images/2022/06/ss1-4.png)
 
-まず知っておくべきは、リンクタグ（アンカータグ）は 4 つの異なる状態（擬似クラス）を持つということです:
+まず、リンクタグ（anchor タグ）が 4 つの異なる状態（擬似クラスとも呼ばれます）になることを知っておくことが重要です。
 
--   `a:link`: リンクがアクティブ、訪問済み、またはホバー状態でない通常の状態
--   `a:visited`: リンクがユーザーによってクリックされた場合、つまり訪問済みの状態
--   `a:hover`: ユーザーがリンクにマウスをホバーしている状態
+-   `a:link`: 通常の状態（アクティブでも訪問済みでもホバーでもない）
+-   `a:visited`: ユーザーがリンクをクリックして訪問した状態
+-   `a:hover`: ユーザーがリンクにホバーしている状態
 -   `a:active`: ユーザーがリンクをクリックしている状態
 
-**注:** CSS のカスケード特性のため、これらの状態（擬似クラス）は上記の順序で記述しなければなりません。
+**注意:** CSS のカスケード特性のため、これらの状態（擬似クラス）は上記の順序で記述する必要があります。
 
-リンクのデフォルトの下線を消すためには、すべての擬似クラスに `text-decoration` プロパティを `none` として指定すれば良いのです。
-
-```
-<p>これは <a href="#">リンク</a> です</p>
-```
+リンクのデフォルトの下線を消すためには、すべての擬似クラスに対して `text-decoration` プロパティに `none` を割り当てればよいです。
 
 ```
-a:link {
-    text-decoration: none;
+<p>This is a <a href="#">link</a></p>
+```
+
+```
+ a:link {
+      text-decoration: none;
 }
 
 a:visited {
-    text-decoration: none;
+      text-decoration: none;
 }
 
 a:hover {
-    text-decoration: none;
+      text-decoration: none;
 }
 
 a:active {
-    text-decoration: none;
+      text-decoration: none;
 }
 ```
 
 ![ss2-4](https://www.freecodecamp.org/news/content/images/2022/06/ss2-4.png)
 
-また、アンカー要素セレクタを使って一度にデフォルトの下線を消すことも可能です:
+また、次のように anchor 要素セレクタを使用して、デフォルトの下線を一括して削除することもできます。
 
 ```
-a {
-    text-decoration: none;
+ a {
+       text-decoration: none;
 }
 ```
 
 ![ss3-5](https://www.freecodecamp.org/news/content/images/2022/06/ss3-5.png)
 
-リンクタグの 4 つの擬似クラスを使って、このペンで試してみましょう:
+リンクタグの 4 つの擬似クラスを使って遊んでみたい方は、こちらの Pen をお試しください:
 
 <iframe width="100%" height="350" src="https://codepen.io/koladechris/embed/bGLPzXr" style="aspect-ratio: 16 / 9; width: 100%; height: auto;" title="CodePen embed" scrolling="no" allowtransparency="true" allowfullscreen="true" loading="lazy"></iframe>
 
-## 結論
+## まとめ
 
-この記事が、CSS を使ってリンクのデフォルトの下線を消す方法を学ぶ助けになれば幸いです。
+この記事が、CSS でリンクのデフォルトの下線を消す方法を学ぶ助けになれば幸いです。
 
-この記事が役に立った場合は、ぜひ友人や家族に共有してください。
+この記事が役立ったと思ったら、ぜひ友達や家族とシェアしてください。
 
-読んでいただき、ありがとうございました。
-
----
-
-![Kolade Chris](https://cdn.hashnode.com/res/hashnode/image/upload/v1720467520534/YTa5HE3R0.jpg)
-
-私はフロントエンド技術に焦点を当てたソフトウェア開発者兼技術ライターです
-
----
-
-ここまで読んでくれたなら、著者に感謝の意を伝えてください。感謝の気持ちを伝える
-
-無料でコーディングを学びましょう。freeCodeCamp のオープンソースカリキュラムは、40,000 人以上が開発者としての仕事を得る手助けをしてきました。 [始める][1]
-
-[1]: https://www.freecodecamp.org/learn/
+読んでくれてありがとう。
 

--- a/articles/zh/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137.md
+++ b/articles/zh/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137.md
@@ -1,0 +1,58 @@
+---
+title: "Rahul Pandey 辞去了年薪 800,000 美元的 FAANG 开发者工作去创业 [播客 #137]"
+date: 2024-08-18T10:55:05.623Z
+author: Quincy Larson
+authorURL: https://www.freecodecamp.org/news/author/quincy/
+originalURL: https://www.freecodecamp.org/news/rahul-pandey-quit-his-800k-per-year-faang-developer-job-to-build-a-startup-podcast-137/
+translator: ""
+reviewer: ""
+---
+
+在本周的播客节目中，freeCodeCamp 创始人 Quincy Larson 采访了 Rahul Pandey。他是一名软件工程师，辞去了年薪 80 万美元的 FAANG 工作，去创办自己的初创公司。
+
+<!-- more -->
+
+我们讨论了以下内容：
+
+-   裁员后的开发者工作环境
+  
+-   开发者面试及如何让自己脱颖而出
+  
+-   为什么薪资谈判仍然有意义
+  
+-   他相信存在 10 倍工程师，甚至 100 倍和 1000 倍工程师
+    
+
+你能猜出我在节目开场演奏的贝斯曲目吗？它来自 1969 年的 Motown 经典。
+
+你可以在 YouTube 上观看这次访谈：
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/v2iRCaIfiSc" style="aspect-ratio: 16 / 9; width: 100%; height: auto;" title="YouTube 视频播放器" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy"></iframe>
+
+你也可以在 Apple Podcasts、Spotify 或你最喜欢的播客应用中收听该节目。一定要关注 freeCodeCamp 播客，这样你就能在每周五收到新节目推送。
+
+另外，我想感谢每月支持我们慈善事业的 10,443 名热心人士，他们让这档播客成为可能。你也可以加入他们，支持我们的使命：[https://www.freecodecamp.org/donate][1]
+
+我们在对话中提到的链接：
+
+-   Rahul 在 freeCodeCamp 上的 Android 应用教程（4 小时观看）：[https://www.freecodecamp.org/news/learn-how-to-build-and-publish-an-android-app-from-scratch/][2]
+  
+-   Rahul 关于大学毕业后工作机会的视频：[https://www.youtube.com/watch?v=rceUVaiXQgU][3]
+  
+-   Rahul 的公司 Taro：[https://www.jointaro.com/][4]
+  
+-   一个软件工程师在父亲去世后回到印度接手父亲化工公司的故事：[https://anandsanwal.me/2018/06/19/dad-company-sale/][5]
+  
+-   Pragmatic Engineer 关于利率与开发者招聘相关性的会议演讲：[https://www.youtube.com/watch?v=VpPPHDxR9aM][6]
+  
+-   Rahul 在 LinkedIn 上的主页：[https://www.linkedin.com/in/rpandey1234/][7]
+    
+
+[1]: https://www.freecodecamp.org/donate
+[2]: https://www.freecodecamp.org/news/learn-how-to-build-and-publish-an-android-app-from-scratch/
+[3]: https://www.youtube.com/watch?v=rceUVaiXQgU
+[4]: https://www.jointaro.com/
+[5]: https://anandsanwal.me/2018/06/19/dad-company-sale/
+[6]: https://www.youtube.com/watch?v=VpPPHDxR9aM
+[7]: https://www.linkedin.com/in/rpandey1234/
+


### PR DESCRIPTION
The includeSelector in the ArticlesAutoTranslate workflow has been updated to 'span.author-card-name,section.post-content' to ignore author's avatar image.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
