### PR TITLE
fix: github-token not supplied error

### DIFF
--- a/.github/workflows/pr-move-card.yml
+++ b/.github/workflows/pr-move-card.yml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       pull-requests: read
       issues: read
-      repository-projects: read # Needed to access project data using secrets.GITHUB_TOKEN
     outputs:
       target_status: 'in Review' # Which status to move the card to
       card_id: ${{ steps.get_card_node_id.outputs.card_id }}
@@ -31,7 +30,7 @@ jobs:
         with:
           script: |
             // Debug log
-            console.log("github.event.pull_request.node_id:", process.env.PR_NODE_ID));
+            console.log("github.event.pull_request.node_id:", process.env.PR_NODE_ID);
 
             // GitHub GraphQL API query
             // Find the relevant GitHub project card's node id by `Closes #XXXXX` reference in the pull request
@@ -114,8 +113,6 @@ jobs:
     name: Update project card
     needs: get_card
     runs-on: ubuntu-latest
-    permissions:
-      repository-projects: write # Needed to access project data using secrets.GITHUB_TOKEN
     steps:
       - name: Debug outputs
         run: |
@@ -126,7 +123,7 @@ jobs:
         uses: titoportas/update-project-fields@v0.1.0
         with:
           project-url: ${{ needs.get_card.outputs.project_url }}
-          github-token: ${{ secrets.MOVE_CARDS_TOKEN }}
+          github-token: ${{ secrets.MOVE_CARDS_TOKEN }} # Need to use PAT to access ProjectsV2
           item-id: ${{ needs.get_card.outputs.card_id }}
           field-keys: Status
           field-values: ${{ needs.get_card.outputs.target_status }}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Changes:
- Use `pull_request_target` event instead of `pull_request` to access repository secrets when the PR is coming from a fork. This should resolve the `Error: Input required and not supplied: github-token` I was seeing [here](https://github.com/freeCodeCamp/news-translation-tasks/actions/runs/10420079829).
  - This workflow only needs to update GitHub project items, but `pull_request_target` grants read/write permission to the repository contents by default. So I set the permission `contents: none`.
- Remove unnecessary actions/checkout
- Add `paths:` filter to trigger this workflow only for translation files
- Add error handling to improve error messages on failure

I have tested these changes in my fork [here](https://github.com/sidemt/news-translation-tasks/actions/runs/10456846379).

Additional info about this workflow:
- I want to let collaborators with `read` role to open PRs to this repository from their fork.
- When a PR is opened (for translations), I want to update the status in the GitHub project.



---

Note for future me: the permission `repository-projects` is [only for projects classic](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)  and didn't seem to work for projectsV2. 