### PR TITLE
chore: update codeowners to i18n team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,10 +8,10 @@
 # -------------------------------------------------
 
 # -------------------------------------------------
-# All files are owned by dev team
+# All files are owned by i18n team
 # -------------------------------------------------
 
-* @freecodecamp/dev-team
+* @freecodecamp/i18n
 
 # --- Owned by none (negate rule above) ---
 
@@ -19,14 +19,13 @@ package.json
 package-lock.json
 
 # -------------------------------------------------
-# All files in the root are owned by dev team
+# All files in the root are owned by i18n team
 # -------------------------------------------------
 
-/* @freecodecamp/dev-team
+/* @freecodecamp/i18n
 
 # --- Owned by none (negate rule above) ---
 
-*.md
 /package.json
 /package-lock.json
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

It seems the dev team was set as code owners when this repo was generated from template freeCodeCamp/template.
Updating it to the i18n team.
