### PR TITLE
Replace deprecated ::set-output with Environment File syntax in slash-command-action.yml

### DIFF
--- a/.github/workflows/slash-command-action.yml
+++ b/.github/workflows/slash-command-action.yml
@@ -27,22 +27,22 @@ jobs:
         run: |
           # For ease of use, accept both /postedit and /post-edit.
           if [[ "$COMMENT" == /postedit* || "$COMMENT" == /post-edit* ]]; then
-            echo "::set-output name=command::postedit"
-            echo "::set-output name=target_status::in Postediting"
-            echo "::set-output name=valid_command::true"
+            echo "command=postedit" >> $GITHUB_OUTPUT
+            echo "target_status=in Postediting" >> $GITHUB_OUTPUT
+            echo "valid_command=true" >> $GITHUB_OUTPUT
           # We can remove this elif condition for /translate when we move to /postedit command completely.
           # Keeping this for now to make the old command work during the transition period.
           elif [[ "$COMMENT" == /translate* ]]; then
-            echo "::set-output name=command::translate"
-            echo "::set-output name=target_status::in Translation"
-            echo "::set-output name=valid_command::true"
+            echo "command=translate" >> $GITHUB_OUTPUT
+            echo "target_status=in Translation" >> $GITHUB_OUTPUT
+            echo "valid_command=true" >> $GITHUB_OUTPUT
           elif [[ "$COMMENT" == /review* ]]; then
-            echo "::set-output name=command::review"
-            echo "::set-output name=target_status::in Review"
-            echo "::set-output name=valid_command::true"
+            echo "command=review" >> $GITHUB_OUTPUT
+            echo "target_status=in Review" >> $GITHUB_OUTPUT
+            echo "valid_command=true" >> $GITHUB_OUTPUT
           else
             echo "::warning::Invalid command. The comment must start with /postedit or /review."
-            echo "::set-output name=valid_command::false"
+            echo "valid_command=false" >> $GITHUB_OUTPUT
           fi
       - name: Get project card
         id: get_card


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This change updates slash-command-action.yml to replace the deprecated ::set-output commands with the recommended $GITHUB_OUTPUT Environment File syntax. It resolves the warning: "The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files," ensuring compatibility with current GitHub Actions best practices.
