### PR TITLE
Fix GitHub Actions bugs: invalid command handling, missing permissions, and deprecated merge strategy

### DIFF
--- a/.github/workflows/ArticlesAutoTranslate.yml
+++ b/.github/workflows/ArticlesAutoTranslate.yml
@@ -206,7 +206,7 @@ jobs:
           fi
 
           # Merge main to get the raw article
-          git merge --strategy=recursive --strategy-option=theirs main || true
+          git merge -X theirs main || true
 
       ### Ensure language directory exists
       - name: Prepare language directory

--- a/.github/workflows/close-non-main-prs.yml
+++ b/.github/workflows/close-non-main-prs.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   close-pr-if-not-main:
     runs-on: ubuntu-latest
-    
+    permissions:
+      pull-requests: write
+      issues: write
+
     steps:
       - name: Close PRs
         uses: actions/github-script@v7

--- a/scripts/validateCommand.js
+++ b/scripts/validateCommand.js
@@ -33,7 +33,7 @@ async function main({ github, context, core }) {
   core.setOutput("target_status", result.targetStatus);
 
   if (!result.isValid) {
-    core.setFailed(
+    core.warning(
       "Invalid command. The comment must start with /postedit or /review."
     );
   }


### PR DESCRIPTION
- validateCommand.js: replace core.setFailed() with core.warning() for invalid
  commands so the validate_and_get_card job succeeds and the assign_issue job
  can run to post the invalid-command reply comment
- close-non-main-prs.yml: add missing permissions (pull-requests: write,
  issues: write) required for closing PRs and posting comments
- ArticlesAutoTranslate.yml: replace deprecated --strategy=recursive
  --strategy-option=theirs with -X theirs to use git's default (ort) strategy

https://claude.ai/code/session_018H6WtM2RQ43eqwh81pAk1E